### PR TITLE
Disable user-select on "selected" in overlay

### DIFF
--- a/wardrobe/static/css/base.css
+++ b/wardrobe/static/css/base.css
@@ -131,6 +131,11 @@ form .required:before {
 }
 
 .tile .overlay span {
+    user-select: none;
+    -moz-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
+
     display: block;
     position: absolute;
     top: 50%;


### PR DESCRIPTION
A small fix that prevents `user-select` on the "selected" text on a tile with an overlay. Example below:

![](https://photos-4.dropbox.com/t/2/AAD32czsgQHPbTvKfBW4VVFbC2JSOxIkaPPOoVxXd32qQA/12/39932457/png/32x32/3/1462003200/0/2/Screenshot%202016-04-29%2020.25.17.png/EJPgux4YvW8gAigC/qqIyGM6V262lDumEVJr8JMs5beAyF0zUBjaaaUQHz1Q?size_mode=3&size=1280x960)

@birkholz If you could review this locally, I tested in browser but I was unable to get server running locally (need to get virtualenv set up).
